### PR TITLE
Optimize performance: fix critical memory and CPU bottlenecks

### DIFF
--- a/SR2MP/Client/Client.cs
+++ b/SR2MP/Client/Client.cs
@@ -263,7 +263,7 @@ public sealed class Client
         return playerManager.GetPlayer(playerId);
     }
 
-    public List<RemotePlayer> GetAllRemotePlayers()
+    public IEnumerable<RemotePlayer> GetAllRemotePlayers()
     {
         return playerManager.GetAllPlayers();
     }

--- a/SR2MP/Packets/Utils/PacketReader.cs
+++ b/SR2MP/Packets/Utils/PacketReader.cs
@@ -43,19 +43,21 @@ public sealed class PacketReader : IDisposable
 
     public List<T> ReadList<T>(Func<PacketReader, T> reader)
     {
-        var list = new List<T>(this.reader.ReadInt32());
+        var count = this.reader.ReadInt32();
+        var list = new List<T>(count);
 
-        for (var i = 0; i < list.Count; i++)
-            list[i] = reader(this);
+        for (var i = 0; i < count; i++)
+            list.Add(reader(this));
 
         return list;
     }
 
     public Dictionary<TKey, TValue> ReadDictionary<TKey, TValue>(Func<PacketReader, TKey> keyReader, Func<PacketReader, TValue> valueReader) where TKey : notnull
     {
-        var dict = new Dictionary<TKey, TValue>(reader.ReadInt32());
+        var count = reader.ReadInt32();
+        var dict = new Dictionary<TKey, TValue>(count);
 
-        for (var i = 0; i < dict.Count; i++)
+        for (var i = 0; i < count; i++)
             dict[keyReader(this)] = valueReader(this);
 
         return dict;

--- a/SR2MP/Server/Handlers/ConnectHandler.cs
+++ b/SR2MP/Server/Handlers/ConnectHandler.cs
@@ -35,7 +35,7 @@ public class ConnectHandler : BasePacketHandler
         {
             Type = (byte)PacketType.ConnectAck,
             PlayerId = playerId,
-            OtherPlayers = Array.ConvertAll(playerManager.GetAllPlayers().ToArray(), input => input.PlayerId),
+            OtherPlayers = playerManager.GetAllPlayers().Select(p => p.PlayerId).ToArray(),
             Money = money,
             RainbowMoney = rainbowMoney
         };

--- a/SR2MP/Server/Managers/ClientManager.cs
+++ b/SR2MP/Server/Managers/ClientManager.cs
@@ -76,21 +76,19 @@ public class ClientManager
         }
     }
 
-    public List<ClientInfo> GetAllClients()
+    public IEnumerable<ClientInfo> GetAllClients()
     {
-        return clients.Values.ToList();
+        return clients.Values;
     }
 
-    public List<ClientInfo> GetTimedOutClients()
+    public IEnumerable<ClientInfo> GetTimedOutClients()
     {
-        return clients.Values
-            .Where(client => client.IsTimedOut())
-            .ToList();
+        return clients.Values.Where(client => client.IsTimedOut());
     }
 
     public void RemoveTimedOutClients()
     {
-        var timedOut = GetTimedOutClients();
+        var timedOut = GetTimedOutClients().ToArray();
         foreach (var client in timedOut)
         {
             RemoveClient(client.GetClientInfo());

--- a/SR2MP/Shared/Managers/PacketChunkManager.cs
+++ b/SR2MP/Shared/Managers/PacketChunkManager.cs
@@ -36,17 +36,27 @@ public static class PacketChunkManager
 
         if (chunkIndex + 1 >= packet.totalChunks)
         {
-            var completeData = new List<byte>();
+            // Calculate total size and allocate single buffer
+            var totalSize = 0;
             foreach (var chunk in packet.chunks)
             {
-                completeData.AddRange(chunk);
+                totalSize += chunk.Length;
+            }
+
+            fullData = new byte[totalSize];
+            var offset = 0;
+
+            // Use Buffer.BlockCopy for efficient copying
+            foreach (var chunk in packet.chunks)
+            {
+                Buffer.BlockCopy(chunk, 0, fullData, offset, chunk.Length);
+                offset += chunk.Length;
             }
 
             incompletePackets.Remove(packetType);
-            
+
             SrLogger.LogPacketSize($"Fully finished merge: type={packetType}");
-            
-            fullData = completeData.ToArray();
+
             return true;
         }
         else

--- a/SR2MP/Shared/Managers/RemotePlayerManager.cs
+++ b/SR2MP/Shared/Managers/RemotePlayerManager.cs
@@ -114,9 +114,9 @@ public class RemotePlayerManager
         }
     }
 
-    public List<RemotePlayer> GetAllPlayers()
+    public IEnumerable<RemotePlayer> GetAllPlayers()
     {
-        return players.Values.ToList();
+        return players.Values;
     }
 
     public void Clear()


### PR DESCRIPTION
Critical Fixes:
- PacketChunkManager: Replace List<byte> + AddRange + ToArray with Buffer.BlockCopy for packet merging Eliminates multiple allocations and array resizing on every packet merge
- PacketReader: Fix ReadList() and ReadDictionary() logic bugs where Count was 0 instead of using capacity Methods were not properly reading data due to incorrect loop bounds

High-Priority Optimizations:
- RemotePlayerManager: Change GetAllPlayers() to return IEnumerable instead of ToList() Removes unnecessary allocation on every broadcast operation
- ClientManager: Optimize GetAllClients() and GetTimedOutClients() to return IEnumerable Significantly reduces GC pressure during frequent broadcast loops
- ConnectHandler: Eliminate double conversion (ToList->ToArray) by using LINQ Select
- RemoteFXManager: Cache FindObjectsOfTypeAll<ParticleSystemRenderer> to avoid duplicate expensive scene scans Reduces initialization time by avoiding second full scene hierarchy search
